### PR TITLE
Using alternatives

### DIFF
--- a/src/main/java/com/tlopes/azure/IMessageClientWrapper.java
+++ b/src/main/java/com/tlopes/azure/IMessageClientWrapper.java
@@ -1,0 +1,14 @@
+package com.tlopes.azure;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+public interface IMessageClientWrapper {
+    // @PostConstruct unfornutally you cannot annotqate a method with @PostConstruct. You need to add it to the implementation
+    void onStart();
+
+    // Same @PreDestroy
+    void onStop() throws InterruptedException;
+
+    String sendMessage();
+}

--- a/src/main/java/com/tlopes/azure/MessagePublisher.java
+++ b/src/main/java/com/tlopes/azure/MessagePublisher.java
@@ -5,9 +5,9 @@ import javax.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class MessagePublisher {
 
-  private final MessageClientWrapper messageClientWrapper;
+  private final IMessageClientWrapper messageClientWrapper;
 
-  public MessagePublisher(final MessageClientWrapper messageClientWrapper) {
+  public MessagePublisher(final IMessageClientWrapper messageClientWrapper) {
     this.messageClientWrapper = messageClientWrapper;
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# If you uncomment this, then the alternative will be used in test
+# %test.quarkus.arc.selected-alternatives=com.tlopes.azure.AlternativeMessageClientWrapper

--- a/src/test/java/com/tlopes/azure/AlternativeMessageClientWrapper.java
+++ b/src/test/java/com/tlopes/azure/AlternativeMessageClientWrapper.java
@@ -1,0 +1,34 @@
+package com.tlopes.azure;
+
+import io.quarkus.arc.DefaultBean;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Alternative;
+
+@ApplicationScoped
+@Alternative
+public class AlternativeMessageClientWrapper implements IMessageClientWrapper {
+
+  @Override
+  @PostConstruct
+  public void onStart() {
+    System.out.println("----------------  Does nothing on start ----------------");
+  }
+
+  @Override
+  @PreDestroy
+  public void onStop() throws InterruptedException {
+    System.out.println("----------------  Does nothing on close ----------------");
+  }
+
+  @Override
+  public String sendMessage() {
+    System.out.println("----------------  Sends nothing to nowhere ----------------");
+    return "Returned alternative client wrapper";
+  }
+}

--- a/src/test/java/com/tlopes/azure/MessagePublisherTest.java
+++ b/src/test/java/com/tlopes/azure/MessagePublisherTest.java
@@ -17,12 +17,12 @@ class MessagePublisherTest {
    * actual connection to IoT Hub, requiring valid connection string.
    * This is not ideal since anyone may forget to inject the mock and end up messing an iot hub instance.
    */
-  @InjectMock
+  @Inject // Do not use @InjectMock
   MessageClientWrapper messageClientWrapper;
 
   @Test
   void publishMessage() {
-    Mockito.when(messageClientWrapper.sendMessage()).thenReturn("Returned mocked client wrapper");
+    // You don't need that anymore Mockito.when(messageClientWrapper.sendMessage()).thenReturn("Returned mocked client wrapper");
 
     messagePublisher.publishMessage();
   }


### PR DESCRIPTION
Basically, this is how it works:

* Do not use CDI Observers. Any bean, injected or not, alternative or not, will observe and react to an event. Instead use @PostConstruct / @PreDestroy
* Introduce an interface `IMessageClientWrapper` so it can have two implementations (real one and alternative one)
* Activate the alternative in the `application.properties` (comment and uncomment it so you can see the difference)
* Do not use `InjectMock` in the test as you are now injecting the real bean (real implementation or alternative depending if you activate the alternative or not)

Let me know if this suits you